### PR TITLE
Fixed create-account feature to ensure it handles form input properly

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,9 +27,15 @@ def verify_password_login(password, user):
     return password == user.password
       
 # Verify password meets requirements for account creation
-def verify_password_create(password, email):
-    nshe = email[0:10]
-    return password == nshe
+def verify_password_create(password, email, role):
+    status = False
+    if role == "student":
+        nshe = email[0:10]
+        status = (password == nshe)
+    elif role == "faculty":
+        status = len(password) >= 8
+
+    return status
         
 ### ---------- Routes ---------- ###
 
@@ -48,6 +54,11 @@ def index():
 @app.route("/create_account")
 def create_account():
     return render_template("create_account.html")
+
+# --- Create Account Faculty Page --- #
+@app.route("/create_account_faculty")
+def create_account_faculty():
+    return render_template("create_account_faculty.html")
 
 # --- Login Page --- #
 @app.route("/login")
@@ -105,13 +116,17 @@ def register():
     #   Returns true if it contains a valid row in the User table
     #   Returns false if the value is "none" - user not found
     if user:
-        return render_template("create-account.html", 
-                               error = "Email in use! - try again")
+        return render_template("create_account.html", 
+                               error = "Email in use - try again")
     
-    # If password is invaid refresh page and return an error message
-    elif not verify_password_create(password, email):
-        return render_template("create-account.html", 
-                error = "Password must match #nshe used in email - try again")
+    # If password is invalid refresh page and return an error message
+    elif not verify_password_create(password, email, role):
+        if (role == "student"):
+            return render_template("create_account.html", 
+                    error = "Invalid password")
+        else:
+            return render_template("create_account_faculty.html", 
+                    error = "Invalid password")
     
     # User doesn't already exist and password is valid... add user to DB
     else:

--- a/templates/create_account_faculty.html
+++ b/templates/create_account_faculty.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Create Account • CSN Exam Registration</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="../static/styles.css" rel="stylesheet">
+</head>
+
+<body class="page--create">
+  <header class="header header--alt">
+    <div class="header__inner">
+      <div><strong>Create Account</strong></div>
+      <nav class="header__nav">
+        <a href="/">Home</a>
+        <a href="login">Sign in</a>
+      </nav>
+    </div>
+  </header>
+
+  <main class="main">
+    <section class="card">
+      <h2 class="card__title">Let’s get you set up</h2>
+      <p class="help" style="margin-top:-6px">Already have an account? <a href="login">Sign in here</a>.</p>
+
+      <form class="form" method="post" action="{{ url_for('register') }}" novalidate>
+        <div class="form__row">
+          <label class="label">I am a</label>
+          <div>
+            <label><input type="radio" name="role" value="student" > Student</label>
+            &nbsp;&nbsp;
+            <label><input type="radio" name="role" value="faculty" checked> Faculty</label>
+          </div>
+        </div>
+
+        <div class="form__row">
+          <label class="label" for="email">CSN Email</label>
+          <input id="email" name="email" class="input" type="email" required
+                 placeholder="1234567890@student.csn.edu"
+                 pattern="\\d{10}@student\\.csn\\.edu">
+          <div id="emailHelp" class="help">
+            Format: <code>NSHE##########@student.csn.edu</code>
+          </div>
+          {% if error %}<label class="label error">{{ error }}</label>{% endif %}
+        </div>
+
+        <div class="form__row" id="passwordRow">
+          <label class="label" for="nshe">Password (Students: NSHE Number)</label>
+          <input id="nshe" name="nshe" class="input" type="password" required inputmode="numeric"
+                 minlength="10" maxlength="10" pattern="\\d{10}">
+          <div id="passHelp" class="help">Exactly 10 digits for students. Faculty can set a secure password.</div>
+        </div>
+
+        <div class="form__row">
+          <label class="label" for="first">First name</label>
+          <input id="first" name="first_name" class="input" type="text" required>
+        </div>
+
+        <div class="form__row">
+          <label class="label" for="last">Last name</label>
+          <input id="last" name="last_name" class="input" type="text" required>
+        </div>
+
+        <button class="button" type="submit" value="Register">Create Account</button>
+      </form>
+    </section>
+  </main>
+
+  <footer class="footer">© CSN Testing Center</footer>
+
+  <script>
+    // Make the page feel different and enforce different email/password rules by role
+    (function(){
+      const roleRadios = document.querySelectorAll('input[name="role"]');
+      const email = document.getElementById('email');
+      const emailHelp = document.getElementById('emailHelp');
+      const pass = document.getElementById('nshe');
+      const passHelp = document.getElementById('passHelp');
+
+      function applyRole(role){
+        if (role === 'student') {
+          email.placeholder = '1234567890@student.csn.edu';
+          email.pattern = '\\\\d{10}@student\\\\.csn\\\\.edu';
+          emailHelp.innerHTML = 'Format: <code>NSHE##########@student.csn.edu</code>';
+
+          pass.type = 'password';
+          pass.inputMode = 'numeric';
+          pass.minLength = 10;
+          pass.maxLength = 10;
+          pass.pattern = '\\\\d{10}';
+          passHelp.textContent = 'Exactly 10 digits for students.';
+        } else {
+          email.placeholder = 'firstname.lastname@csn.edu';
+          email.pattern = '^[A-Za-z][A-Za-z.\\-]*@csn\\.edu$';
+          emailHelp.textContent = 'Format: firstname.lastname@csn.edu';
+
+          pass.type = 'password';
+          pass.inputMode = 'text';
+          pass.minLength = 8;
+          pass.maxLength = 64;
+          pass.removeAttribute('pattern');
+          passHelp.textContent = 'Use at least 8 characters (letters, numbers, symbols).';
+        }
+      }
+
+      roleRadios.forEach(r => r.addEventListener('change', e => applyRole(e.target.value)));
+      applyRole(document.querySelector('input[name="role"]:checked').value);
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
- When create-account page refreshes due to an error, it now ensures the correct role is still highlighted when you try creating an account again.
- Faculty sign up now ensures that password is at least 8 characters long.
- Created a duplicate of the create_account page called create_account_faculty (only difference is that faculty is checked by default on the create_account_faculty page..